### PR TITLE
fix: new Config form to save form fields correctly based on selected type

### DIFF
--- a/api/Configuration/index.ts
+++ b/api/Configuration/index.ts
@@ -8,6 +8,7 @@ export interface IConfiguration {
     name?: string
     owner?: string
     manager?: string
+    role?: string
     created_at: Date
 }
 

--- a/src/pages/Configurations/ConfigurationsNew/index.tsx
+++ b/src/pages/Configurations/ConfigurationsNew/index.tsx
@@ -34,28 +34,35 @@ export const ConfigurationsNew = () => {
     const [configurationType, setConfigurationType] = useState<configurationType>();
     
     const inputApplicationRef = createRef<HTMLSelectElement>()
-    const inputOwnerRef = createRef<HTMLSelectElement>()
     const inputTypeRef = createRef<HTMLSelectElement>()
+    const inputNewNameRef = createRef<HTMLInputElement>()
+    const inputOwnerRef = createRef<HTMLSelectElement>()
     const inputManagerRef = createRef<HTMLSelectElement>()
     const inputRoleRef= createRef<HTMLSelectElement>()
 
     const navigate = useNavigate();
 
-    const handleOnSubmit = async (event:React.FormEvent<HTMLFormElement>): void => {
+    const handleOnSubmit = async (event:React.FormEvent<HTMLFormElement>): Promise<void> => {
         event.preventDefault();
         
-        const owner: string | undefined = inputOwnerRef.current?.value;
-        const type: string | undefined = inputTypeRef.current?.value;
-        const application: string | undefined = inputApplicationRef.current?.value;
         const uuid: string = uuidv4();
+        const application: string | undefined = inputApplicationRef.current?.value;
+        const type: string | undefined = inputTypeRef.current?.value;
+        const name: string | undefined = inputNewNameRef.current?.value;
+        const owner: string | undefined = inputOwnerRef.current?.value;
+        const manager: string | undefined = inputManagerRef.current?.value;
+        const role: string | undefined = inputRoleRef.current?.value;
         const created_at: Date = new Date();
         
         if(owner && type && application) {
             const payload: IConfiguration = {
                 uuid,
-                owner,
-                type,
                 application,
+                type,
+                name,
+                owner,
+                manager,
+                role,
                 created_at
             };
             await createConfiguration(payload);
@@ -123,6 +130,7 @@ export const ConfigurationsNew = () => {
                                                 className="input"
                                                 name="name"
                                                 placeholder="New name"
+                                                ref={inputNewNameRef}
                                                 type="text"
                                             />
                                             <Select


### PR DESCRIPTION
As a Developer, I would like to fix the New Configuration form to save form fields correctly based on the selected configuration type.

closes #38 